### PR TITLE
Move phaser-ce library to peerDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,24 @@
 # RobotlegsJS Phaser-CE Changelog:
 
-## RobotlegsJS Phaser-CE 0.1.0
+## RobotlegsJS Phaser-CE 0.2.0
 
-### v0.1.0
+### v0.2.0
+
+Major Breaking Changes:
+---
 
 - Rename package to `@robotlegsjs/phaser-ce` and move to [RobotlegsJS-Phaser-CE](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-CE) (see #2).
 
-- Update @robotlegsjs/core to version 0.2.0 (see [51](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/pull/51)).
+- Move `phaser-ce` library to **peerDependencies**, allowing the final user to choose the desired version of the `phaser-ce` library on each project (see #3).
 
-- Update phaser-ce to version 2.11.0 (see [46](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/pull/46)).
+- Update `@robotlegsjs/core` to version `0.2.0` (see [51](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/pull/51)).
 
-- Remove eventemitter3 dependency (see [45](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/pull/45)).
+Features Or Improvements:
+---
+
+- Update `phaser-ce` to version `2.11.0` (see [46](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/pull/46)).
+
+- Remove `eventemitter3` dependency (see [45](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/pull/45)).
 
 - Add changelog (see [35](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/pull/35)).
 
@@ -40,9 +48,9 @@
 
 ### [v0.0.5](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/releases/tag/0.0.5) - 2017-09-26
 
-- Update @robotlegsjs/core to version 0.0.6 (see [9](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/pull/9)).
+- Update `@robotlegsjs/core` to version `0.0.6` (see [9](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/pull/9)).
 
-- Update phaser-ce to version 2.8.8 (see [10](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/pull/10)).
+- Update `phaser-ce` to version `2.8.8` (see [10](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/pull/10)).
 
 - Adapt to NPM [v5.0.0](http://blog.npmjs.org/post/161081169345/v500) (see [7](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/pull/7)).
 
@@ -50,9 +58,9 @@
 
 ### [v0.0.4](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/releases/tag/0.0.4) - 2017-09-15
 
-- Update @robotlegsjs/core to version 0.0.5 (see [5](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/pull/5)).
+- Update `@robotlegsjs/core` to version `0.0.5` (see [5](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/pull/5)).
 
-- Update phaser-ce to version 2.8.7 (see [6](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/pull/6)).
+- Update `phaser-ce` to version `2.8.7` (see [6](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/pull/6)).
 
 - Update TSLint rules (see [6](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/pull/6)).
 
@@ -64,9 +72,9 @@
 
 ### [v0.0.3](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/releases/tag/0.0.3) - 2017-08-30
 
-- Update @robotlegsjs/core to version 0.0.4 (see [4](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/pull/4)).
+- Update `@robotlegsjs/core` to version `0.0.4` (see [4](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/pull/4)).
 
-- Update phaser-ce to version 2.8.4.
+- Update `phaser-ce` to version `2.8.4`.
 
 - Enable GreenKeeper.
 
@@ -74,7 +82,7 @@
 
 ### [v0.0.2](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/releases/tag/0.0.2) - 2017-08-12
 
-- Update @robotlegsjs/core to version 0.0.3.
+- Update `@robotlegsjs/core` to version `0.0.3`.
 
 - Update contributing guidelines.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Installation
 You can get the latest release and the type definitions using [NPM](https://www.npmjs.com/):
 
 ```bash
-npm install @robotlegsjs/phaser-ce --save
+npm install @robotlegsjs/phaser-ce --save-prod
 ```
 
 Or using [Yarn](https://yarnpkg.com/en/):
@@ -29,7 +29,34 @@ Or using [Yarn](https://yarnpkg.com/en/):
 yarn add @robotlegsjs/phaser-ce
 ````
 
+From version `0.2.0` of this package, the [Phaser-CE](https://github.com/photonstorm/phaser-ce) dependency was moved to **peerDependencies**,
+allowing the final user to choose the desired version of the `phaser-ce` library on each project.
+
+The `@robotlegsjs/phaser-ce` package is compatible with versions between the `>=2.8.1 <3` version range of `phaser-ce` library.
+
+As example, when you would like to use the version `2.8.1` of `phaser-ce` library, you can run:
+
+```bash
+npm install phaser-ce@2.8.1 reflect-metadata --save-prod
+```
+
+or
+
+```bash
+yarn add phaser-ce@2.8.1 reflect-metadata
+```
+
 Then follow the [installation instructions](https://github.com/RobotlegsJS/RobotlegsJS/blob/master/README.md#installation) of **RobotlegsJS** library to complete the setup of your project.
+
+**Dependencies**
+
++ [RobotlegsJS](https://github.com/RobotlegsJS/RobotlegsJS)
++ [tslib](https://github.com/Microsoft/tslib)
+
+**Peer Dependencies**
+
++ [Phaser-CE](https://github.com/photonstorm/phaser-ce)
++ [reflect-metadata](https://github.com/rbuckton/reflect-metadata)
 
 Usage
 ---
@@ -82,6 +109,23 @@ new Game();
 ```
 
 [See example](example)
+
+Running the example
+---
+
+Run the following commands to run the example:
+
+```bash
+npm install
+npm start
+```
+
+or:
+
+```bash
+yarn install
+yarn start
+```
 
 License
 ---

--- a/package.json
+++ b/package.json
@@ -48,8 +48,11 @@
   "homepage": "https://github.com/RobotlegsJS/RobotlegsJS-Phaser-CE#readme",
   "dependencies": {
     "@robotlegsjs/core": "^0.2.0",
-    "phaser-ce": "^2.11.0",
     "tslib": "^1.9.3"
+  },
+  "peerDependencies": {
+    "phaser-ce": "^2.8.1",
+    "reflect-metadata": "^0.1.12"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.23",
@@ -81,6 +84,7 @@
     "karma-sourcemap-writer": "^0.1.2",
     "karma-webpack": "^3.0.0",
     "mocha": "^5.2.0",
+    "phaser-ce": "^2.11.0",
     "prettier": "^1.14.0",
     "publish-please": "^3.2.0",
     "reflect-metadata": "^0.1.12",
@@ -97,8 +101,5 @@
     "webpack-cli": "^3.1.0",
     "webpack-concat-plugin": "^3.0.0",
     "webpack-dev-server": "^3.1.5"
-  },
-  "peerDependencies": {
-    "reflect-metadata": "^0.1.12"
   }
 }


### PR DESCRIPTION
Move `phaser-ce` library to **peerDependencies**, allowing the final user to choose the desired version of the `phaser-ce` library on each project.